### PR TITLE
Using getSimpleName() instead of getName() for a shorter preferences …

### DIFF
--- a/keystore/src/main/java/com/github/leonardoxh/keystore/CipherPreferencesStorage.java
+++ b/keystore/src/main/java/com/github/leonardoxh/keystore/CipherPreferencesStorage.java
@@ -21,7 +21,7 @@ import android.util.Base64;
 import javax.annotation.Nullable;
 
 final class CipherPreferencesStorage {
-    private static final String SHARED_PREFERENCES_NAME = CipherPreferencesStorage.class.getName() + "_security_storage";
+    private static final String SHARED_PREFERENCES_NAME = CipherPreferencesStorage.class.getSimpleName() + "_security_storage";
 
     private CipherPreferencesStorage() {
         throw new AssertionError();


### PR DESCRIPTION
…file name

Since this preferences file contains secure data, I would not want it to be included by Android's auto backup. So when defining exclude rules, it would be nice to have a shorter name for the preference file name (removing the package name of the CipherPreferencesStorage class).